### PR TITLE
prevent sublevel being installed multiple times

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,6 +6,8 @@ var fixRange     = require('level-fix-range')
 var Hooks   = require('level-hooks')
 
 module.exports   = function (db, sep) {
+  if (db.sublevel) return db
+
   //use \xff (255) as the seperator,
   //so that sections of the database will sort after the regular keys
   sep = sep || '\xff'


### PR DESCRIPTION
This way, every plugin that needs `level-sublevel` internally can just do

``` js
module.exports = function (db) {
  db = SubLevel(db)
  // ...
}
```

And that is safe! So you no longer have to teach people about sublevel in order to use some of your modules.
