### PR TITLE
add entire MIT license text

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,1 +1,19 @@
-Copyright (c) 2013
+Copyright (c) 2013 Dominic Tarr
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.


### PR DESCRIPTION
The conditions under which a user receives a piece of software should be unambiguous and as easy to consume as possible. This, along with the right kind of license, helps to remove risk from users in the event of an intellectual property dispute (whether on the part of the author or another interested party).

In my opinion, the easiest way to achieve this is to include the entire text of the license conditions with the software as it is distributed.

I've taken the liberty of including the entire "MIT" license (as specified here http://opensource.org/licenses/MIT), with the copyright holder being named as Dominic Tarr.

Please review the content of the license before accepting this patch!
