### PR TITLE
Support for chained batches

### DIFF
--- a/batch.js
+++ b/batch.js
@@ -1,0 +1,38 @@
+function addOperation (type, key, value, options) {
+  var operation = {
+    type: type,
+    key: key,
+    value: value,
+    options: options
+  }
+
+  if (options && options.prefix) {
+    operation.prefix = options.prefix
+    delete options.prefix
+  }
+
+  this._operations.push(operation)
+
+  return this
+}
+
+function Batch(sdb) {
+  this._operations = []
+  this._sdb = sdb
+
+  this.put = addOperation.bind(this, 'put')
+  this.del = addOperation.bind(this, 'del')
+}
+
+var B = Batch.prototype
+
+
+B.clear = function () {
+  this._operations = []
+}
+
+B.write = function (cb) {
+  this._sdb.batch(this._operations, cb)
+}
+
+module.exports = Batch

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 var EventEmitter = require('events').EventEmitter
 var next         = process.nextTick
 var SubDb        = require('./sub')
+var Batch        = require('./batch')
 var fixRange     = require('level-fix-range')
 
 var Hooks   = require('level-hooks')
@@ -69,11 +70,11 @@ module.exports   = function (_db, options) {
   db.createKeyStream   = safeRange(db.createKeyStream)
   db.valuesStream =
   db.createValueStream = safeRange(db.createValueStream)
-  
+
   var batch = db.batch
   db.batch = function (changes, opts, cb) {
     if(!Array.isArray(changes))
-      throw new Error('batch must be passed an Array')
+      return new Batch(db)
     changes.forEach(function (e) {
       if(e.prefix) {
         if('function' === typeof e.prefix.prefix)

--- a/sub.js
+++ b/sub.js
@@ -3,6 +3,7 @@ var inherits     = require('util').inherits
 var ranges       = require('string-range')
 var fixRange     = require('level-fix-range')
 var xtend        = require('xtend')
+var Batch        = require('./batch')
 
 inherits(SubDB, EventEmitter)
 
@@ -79,7 +80,7 @@ SDB.del = function (key, opts, cb) {
 
 SDB.batch = function (changes, opts, cb) {
   if(!Array.isArray(changes))
-    throw new Error('batch must be passed an Array')
+    return new Batch(this)
   var self = this,
       res = this._getOptsAndCb(opts, cb)
   changes.forEach(function (ch) {

--- a/test/batch.js
+++ b/test/batch.js
@@ -9,7 +9,7 @@ function all (db, cb) {
     fin = true
     cb(err, obj)
   }
-  
+
   db.createReadStream({end: '\xff\xff'})
     .on('data', function (ch) {
       obj[ch.key] = ch.value
@@ -142,3 +142,153 @@ test('sublevel - prefixed batches on subsection - strings', function (t) {
   })
 })
 
+test('sublevel - batch - chained', function (t) {
+
+  var base = sl('test-sublevel5')
+
+  var a    = base.sublevel('A')
+  var b    = base.sublevel('B')
+
+
+  var sum  = 0
+
+  a.batch()
+    .put('a', 1)
+    .put('b', 2)
+    .put('c', 3)
+    .put('d', 4)
+    .put('e', 5)
+  .write(function (err) {
+    all(a, function (err, obj) {
+      t.notOk(err)
+      var keys = Object.keys(obj).join('')
+      for(var k in obj) {
+        sum += Number(obj[k])
+      }
+      t.equal(keys, 'abcde')
+      t.equal(sum, 15)
+      t.end()
+    })
+  })
+
+})
+
+test('sublevel - prefixed batches - chained', function (t) {
+
+  var base = sl('test-sublevel6')
+
+  var a    = base.sublevel('A')
+  var b    = base.sublevel('B')
+
+  base.batch()
+    .put('a', 1)
+    .put('b', 2, {prefix: b})
+    .put('c', 3)
+    .put('d', 4, {prefix: a})
+    .put('e', 5, {prefix: base})
+  .write(function (err) {
+    all(base, function (_, obj) {
+      t.deepEqual(obj, {
+        'a': '1',
+        'c': '3',
+        'e': '5',
+        '~A~d': '4',
+        '~B~b': '2'
+      })
+      console.log(obj)
+      t.end()
+    })
+  })
+})
+
+test('sublevel - prefixed batches on subsection - chained', function (t) {
+
+  var base = sl('test-sublevel7')
+
+  var a    = base.sublevel('A')
+  var b    = base.sublevel('B')
+
+  a.batch()
+    .put('a', 1, {prefix: base})
+    .put('b', 2, {prefix: b})
+    .put('c', 3, {prefix: base})
+    .put('d', 4)
+    .put('e', 5, {prefix: base})
+  .write(function (err) {
+    all(base, function (_, obj) {
+      t.deepEqual(obj, {
+        'a': '1',
+        'c': '3',
+        'e': '5',
+        '~A~d': '4',
+        '~B~b': '2'
+      })
+      t.end()
+    })
+  })
+})
+
+
+test('sublevel - prefixed batches on subsection - strings - chained', function (t) {
+
+  var base = sl('test-sublevel8')
+
+  var a    = base.sublevel('A')
+  var b    = base.sublevel('B')
+  var b_c    = b.sublevel('C')
+
+  base.batch()
+    .put('a', 1)
+    .put('b', 2, {prefix: b.prefix()})
+    .put('c', 3)
+    .put('d', 4, {prefix: a.prefix()})
+    .put('e', 5)
+    .put('f', 6, {prefix: b_c.prefix()})
+  .write(function (err) {
+    all(base, function (_, obj) {
+      t.deepEqual(obj, {
+        'a': '1',
+        'c': '3',
+        'e': '5',
+        '~A~d': '4',
+        '~B~b': '2',
+        '~B~~C~f': '6'
+      })
+      console.log(obj)
+      t.end()
+    })
+  })
+})
+
+test('sublevel - delete - chained', function(t) {
+  var base = sl('test-sublevel9')
+
+  var a    = base.sublevel('A')
+  var b    = base.sublevel('B')
+
+  var sum  = 0
+
+  a.batch()
+    .put('a', 1)
+    .put('b', 2)
+    .put('c', 3)
+    .put('d', 4)
+    .put('e', 5)
+  .write()
+
+  a.batch()
+    .del('c')
+    .del('e')
+  .write(function (err) {
+    all(a, function (err, obj) {
+      t.notOk(err)
+      var keys = Object.keys(obj).join('')
+      for(var k in obj) {
+        sum += Number(obj[k])
+      }
+      t.equal(keys, 'abd')
+      t.equal(sum, 7)
+      t.end()
+    })
+  })
+})


### PR DESCRIPTION
Proposed solution for issue #44

Ideally, it should pay attention to options objects beyond just the prefix option, but I didn’t feel like messing with the original batch functions that much.
