### PR TITLE
Handle special properties like __proto__

### DIFF
--- a/shell.js
+++ b/shell.js
@@ -102,8 +102,8 @@ var sublevel = module.exports = function (nut, prefix, createStream, options) {
   }
 
   emitter.sublevel = function (name, opts) {
-    return emitter.sublevels[name] =
-      emitter.sublevels[name] || sublevel(nut, prefix.concat(name), createStream, mergeOpts(opts))
+    return emitter.sublevels['$' + name] =
+      emitter.sublevels['$' + name] || sublevel(nut, prefix.concat(name), createStream, mergeOpts(opts))
   }
 
   emitter.pre = function (key, hook) {

--- a/test/special-names.js
+++ b/test/special-names.js
@@ -1,0 +1,45 @@
+var levelup = require('level-test')()
+
+var base = require('../')(levelup('test-sublevels'))
+
+var test = require('tape')
+
+test('special names', function (t) {
+  t.deepEqual(base.sublevels, {})
+
+  var cons = base.sublevel('constructor')
+  var proto = base.sublevel('__proto__')
+  var toString = base.sublevel('toString')
+
+  t.deepEqual(base.sublevels, {
+    '$constructor': cons,
+    '$__proto__': proto,
+    '$toString': toString
+  })
+  t.deepEqual(cons.sublevels, {})
+
+  t.strictEqual(base.sublevel('constructor'), cons)
+  t.strictEqual(base.sublevel('__proto__'), proto)
+  t.strictEqual(base.sublevel('toString'), toString)
+
+  t.deepEqual(cons.prefix(), ['constructor'])
+  t.deepEqual(proto.prefix(), ['__proto__'])
+  t.deepEqual(toString.prefix(), ['toString'])
+
+  var consBlerg = cons.sublevel('blerg')
+  t.deepEqual(cons.sublevels, {'$blerg': consBlerg})
+  t.strictEqual(cons.sublevel('blerg'), consBlerg)
+  t.deepEqual(consBlerg.prefix(), ['constructor', 'blerg'])
+
+  var consProto = cons.sublevel('__proto__')
+  t.deepEqual(cons.sublevels, {'$blerg': consBlerg, '$__proto__': consProto})
+  t.strictEqual(cons.sublevel('__proto__'), consProto)
+  t.deepEqual(consProto.prefix(), ['constructor', '__proto__'])
+
+  t.end()
+})
+
+
+
+
+

--- a/test/sublevels.js
+++ b/test/sublevels.js
@@ -10,7 +10,7 @@ test('subsections', function (t) {
   var foo = base.sublevel('foo')
   var bar = base.sublevel('bar')
 
-  t.deepEqual(base.sublevels, {foo: foo, bar: bar})
+  t.deepEqual(base.sublevels, {'$foo': foo, '$bar': bar})
   t.deepEqual(foo.sublevels, {})
 
   t.strictEqual(base.sublevel('foo'), foo)
@@ -20,7 +20,7 @@ test('subsections', function (t) {
   console.log('prefix:', bar.prefix())
 
   var fooBlerg = foo.sublevel('blerg')
-  t.deepEqual(foo.sublevels, {blerg: fooBlerg})
+  t.deepEqual(foo.sublevels, {'$blerg': fooBlerg})
 
   t.strictEqual(foo.sublevel('blerg'), fooBlerg)
 


### PR DESCRIPTION
Because you're using `sublevels` as a plain map of course, I happened across this because my sublevels were generated by external data and one was called `'constructor'`, bzzt!

This is a breaking change if you choose to accept it because `sublevels` is intended (I guess) to be exposed publicly.
