### PR TITLE
support sublevel(sublevel(db))

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,12 @@ var merge = require('xtend')
 
 var ReadStream = require('levelup/lib/read-stream')
 
-module.exports = function (db, opts) {
+var sublevel = function (db, opts) {
   opts = merge(db.options, opts)
   return shell ( nut ( db, precodec, codec ), [], ReadStream, opts)
+}
+
+module.exports = function (db, opts) {
+  if (typeof db.sublevel === 'function' && typeof db.clone === 'function') return db.clone(opts)
+  return sublevel(db, opts)
 }

--- a/shell.js
+++ b/shell.js
@@ -103,6 +103,10 @@ var sublevel = module.exports = function (nut, prefix, createStream, options) {
     })
   }
 
+  emitter.clone = function(opts) {
+    return sublevel(nut, prefix, createStream, mergeOpts(opts))
+  }
+
   emitter.sublevel = function (name, opts) {
     return emitter.sublevels[name] =
       emitter.sublevels[name] || sublevel(nut, prefix.concat(name), createStream, mergeOpts(opts))


### PR DESCRIPTION
Currently this does not work

``` js
var sublevel = require('level-sublevel')
var db = ...
var sub = sublevel(sublevel(db))
```

This PR fixes this by detecting that the db passed to the constructor is a sublevel and returning a cloned instance of that. By cloning the instance stuff like changing the options should also work
