### PR TITLE
expose a leveldown instance

### DIFF
--- a/nut.js
+++ b/nut.js
@@ -61,6 +61,7 @@ module.exports = function (db, precodec, codec, compare) {
   }
 
   return {
+    db: db,
     apply: function (ops, opts, cb) {
       //apply prehooks here.
       for(var i = 0; i < ops.length; i++) {

--- a/shell.js
+++ b/shell.js
@@ -24,6 +24,15 @@ var sublevel = module.exports = function (nut, prefix, createStream, options) {
 
   emitter.version = version
 
+  // set the leveldown instance
+  emitter.db = nut.db.db ? nut.db.db : nut.db
+  // work around DeferredLevelDown limitations
+  if (typeof nut.db.once === 'function') {
+    nut.db.once('open', function onOpen() {
+      emitter.db = nut.db.db ? nut.db.db : nut.db
+    })
+  }
+
   emitter.methods = {}
   prefix = prefix || []
 


### PR DESCRIPTION
In the same vain as #77

A levelup instance exposes a `db` property that is a leveldown
    instance. This is documented in the levelup README.

Here we expose the leveldown instance through nut and also
    work around the fact that levelup uses a DeferredLevelDown
    instance and later mutates itself to set a real leveldown instance
    to the db field.

cc @dominictarr
