### PR TITLE
Use https:// instead of git:// to make npm install work behind http prox...

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "homepage": "https://github.com/dominictarr/level-sublevel",
   "repository": {
     "type": "git",
-    "url": "git://github.com/dominictarr/level-sublevel.git"
+    "url": "https://github.com/dominictarr/level-sublevel.git"
   },
   "dependencies": {
     "pull-stream": "~2.21.0",


### PR DESCRIPTION
Use https:// instead of git:// to make npm install work behind http proxy