### PR TITLE
Able to pass in string for prefix

### DIFF
--- a/nut.js
+++ b/nut.js
@@ -8,6 +8,7 @@ function isFunction (f) {
 function getPrefix (db) {
   if(db == null) return db
   if(isFunction(db.prefix)) return db.prefix()
+  if(typeof db === 'string') return [db]
   return db
 }
 
@@ -78,7 +79,7 @@ module.exports = function (db, precodec, codec, compare) {
 
       opts = opts || {}
 
-      if('object' !== typeof opts) throw new Error('opts must be object, was:'+ opts) 
+      if('object' !== typeof opts) throw new Error('opts must be object, was:'+ opts)
 
       if('function' === typeof opts) cb = opts, opts = {}
 


### PR DESCRIPTION
This way we can use batch operations with multilevel / RPC since we don't have to pass in a sublevel instance.