### PR TITLE
Remove non-licensed module

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "ltgt": "~2.1.1",
     "levelup": "~0.19.0",
     "xtend": "~4.0.0",
-    "bytewise": "~0.7.1",
+    "bytewise": "~1.1.0",
     "typewiselite": "~1.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Hello! My team is preparing for distribution and I’m checking all our dependencies’ licenses using [license-checker](https://github.com/davglass/license-checker). level-sublevel indirectly depends on base64-js version 0.0.2, which unfortunately has no license. Here’s that piece of the dependency tree:

```shell
├─┬ bytewise@0.7.1
│ └─┬ bops@0.1.1
│   ├── base64-js@0.0.2
│   └── to-utf8@0.0.1
```

Upgrading to bytewise 1.1.0 removes the bops dependency, addressing the issue. All the tests are passing for me, too:

![leves-sublevel-tests](https://cloud.githubusercontent.com/assets/1858316/12490640/6f4d2424-c02b-11e5-9cdc-9ec2dd0c6c66.jpg)

(They’re chatty, but they pass. Not sure why `grep`’s outputing that.)